### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluent::Plugin::Forward-AWS
+# Fluent::Plugin::Forward, a plugin for [Fluentd](http://fluentd.org)-AWS
 
 Forward-AWS plugin forwards log through Amazon Web Service.  
 It uses S3 as log storage, and SNS+SQS for notification.  


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
