### PR TITLE
Support label feature

### DIFF
--- a/fluent-plugin-forward-aws.gemspec
+++ b/fluent-plugin-forward-aws.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", [">= 0.10.58", "< 2"]
   gem.add_runtime_dependency "aws-sdk", "~> 1.8.2"
   
   gem.add_development_dependency 'rake', '~> 0.9.2.2'

--- a/lib/fluent/plugin/in_forward_aws.rb
+++ b/lib/fluent/plugin/in_forward_aws.rb
@@ -191,7 +191,7 @@ class Fluent::ForwardAWSInput < Fluent::Input
             (tag, time, record) = event
             # Apply HandleTagNameMixin manually
             filter_record(tag, time, record)
-            Fluent::Engine.emit(tag,time,record)
+            router.emit(tag,time,record)
           }
         }
         return true


### PR DESCRIPTION
router.emit API causes following effect:
- Fluentd 0.10.58 or later --- Nothing to do. Equivarent to Fluent::Engine.emit.
- Fluentd 0.12.0 or later --- Enabled label feature.
