### PR TITLE
Use test unit gem explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1
+  - 2.2
 
 branches:
   only:

--- a/fluent-plugin-forward-aws.gemspec
+++ b/fluent-plugin-forward-aws.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "fluentd"
   gem.add_runtime_dependency "aws-sdk", "~> 1.8.2"
-  
+
   gem.add_development_dependency 'rake', '~> 0.9.2.2'
   gem.add_development_dependency 'rdoc', '~> 3.12'
+  gem.add_development_dependency 'test-unit', '>= 3.1.0'
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minutest with test-unit compatible API.
