### PR TITLE
Support secret parameter feature

### DIFF
--- a/lib/fluent/plugin/in_forward_aws.rb
+++ b/lib/fluent/plugin/in_forward_aws.rb
@@ -27,9 +27,9 @@ class Fluent::ForwardAWSInput < Fluent::Input
   config_param :channel, :string, :default => "default"
   config_param :channelEnableRegEx, :bool, :default => false
 
-  config_param :aws_access_key_id, :string, :default => nil
-  config_param :aws_secret_access_key, :string, :default => nil
-  
+  config_param :aws_access_key_id, :string, :default => nil, :secret => true
+  config_param :aws_secret_access_key, :string, :default => nil, :secret => true
+
   config_param :aws_s3_endpoint, :string, :default => nil
   config_param :aws_s3_bucketname, :string, :default => nil
   config_param :aws_s3_skiptest, :bool, :default => false

--- a/lib/fluent/plugin/out_forward_aws.rb
+++ b/lib/fluent/plugin/out_forward_aws.rb
@@ -17,9 +17,9 @@ class Fluent::ForwardAWSOutput < Fluent::TimeSlicedOutput
   
   config_param :channel, :string, :default => "default"
 
-  config_param :aws_access_key_id, :string, :default => nil
-  config_param :aws_secret_access_key, :string, :default => nil
-  
+  config_param :aws_access_key_id, :string, :default => nil, :secret => true
+  config_param :aws_secret_access_key, :string, :default => nil, :secret => true
+
   config_param :aws_s3_endpoint, :string, :default => nil
   config_param :aws_s3_bucketname, :string, :default => nil
   config_param :aws_s3_skiptest, :bool, :default => false


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
This feature is concealing given parameters with xxxxxx when specified `:secret => true` in config_param.
